### PR TITLE
Fix auto assignment to use history snapshot

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -528,10 +528,17 @@ socket.on('team:bid_free', ({ value }, cb) => {
 
 
     team.credits -= p;
-    const player = room.viewPlayers[room.currentIndex];
-    last.playerName = player?.name || '(??)';
-    last.role = player?.role || '';
-    team.acquisitions.push({ player: last.playerName, role: last.role, price: p, at: Date.now() });
+    const playerName = last.playerName && String(last.playerName).trim() ? last.playerName : '(??)';
+    const role = last.role || '';
+    const playerTeam = last.playerTeam || '';
+    const playerFm = last.playerFm ?? null;
+
+    last.playerName = playerName;
+    last.role = role;
+    last.playerTeam = playerTeam;
+    last.playerFm = playerFm;
+
+    team.acquisitions.push({ player: playerName, role, price: p, at: Date.now() });
 
     removeCurrentFromMaster(room);
 

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -93,11 +93,31 @@ export function rebuildView(room, startLetter /* opzionale: 'A'..'Z' */){
 
 
 export function removeCurrentFromMaster(room){
-  const cp = room.viewPlayers[room.currentIndex];
-  if (!cp) return;
-  const idx = room.players.findIndex(p => p.name === cp.name && p.role === cp.role);
-  if (idx >= 0) room.players.splice(idx, 1);
-  rebuildView(room);
+  const last = room.history[room.history.length - 1];
+  if (!last) return;
+
+  const targetName = last.playerName || '';
+  const targetRole = last.role || '';
+  if (!targetName || !targetRole) return;
+
+  const idx = room.players.findIndex(p => {
+    if (!p) return false;
+    if (p.name !== targetName || p.role !== targetRole) return false;
+
+    if (last.playerTeam && (p.team || '') !== last.playerTeam) return false;
+
+    if (last.playerFm != null && last.playerFm !== '') {
+      if (p.fm != null && p.fm !== '') return String(p.fm) === String(last.playerFm);
+      return true;
+    }
+
+    return true;
+  });
+
+  if (idx >= 0) {
+    room.players.splice(idx, 1);
+    rebuildView(room);
+  }
 }
 
 export function addBackToMaster(room, player){
@@ -172,7 +192,9 @@ export function mkHistoryPending(room){
     teamName: team.name,
     price: room.topBid || 0,
     playerName: cur?.name || '',           // subito nome/ruolo correnti
-    role: cur?.role || ''
+    role: cur?.role || '',
+    playerTeam: cur?.team || '',
+    playerFm: cur?.fm ?? null
   };
 
   room.history.push(entry);


### PR DESCRIPTION
## Summary
- persist the team and fantamedia snapshot for each pending history entry
- consume the stored history snapshot during auto-assignment instead of relying on the filtered view
- delete players from the master list using the saved history metadata to avoid removing the wrong entry

## Testing
- not run (server-side changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cad10e7610832a911f772c155dd269