### PR TITLE
Fix auto assignment to use history snapshot and host PIN prompt

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -305,14 +305,19 @@ $('btnHostToggle').onclick = () => {
   const payload = {};
   if (!document.body.dataset.hostPinAsked) {
     const pin = prompt('PIN banditore (se configurato):') || '';
-    payload.pin = pin; document.body.dataset.hostPinAsked = '1';
+    payload.pin = pin;
   }
   socket.emit('host:toggle', payload, (res)=>{
-    if(res?.error) return notify(res.error, 'error');
+    if(res?.error) {
+      delete document.body.dataset.hostPinAsked;
+      return notify(res.error, 'error');
+    }
     if (res.host && res.hostToken) {
+      document.body.dataset.hostPinAsked = '1';
       try { localStorage.setItem('hostToken', res.hostToken); } catch(_){}
       notify('Hai preso il ruolo di banditore', 'info');
     } else if (!res.host) {
+      delete document.body.dataset.hostPinAsked;
       try { localStorage.removeItem('hostToken'); } catch(_){}
       notify('Hai lasciato il ruolo', 'info');
     }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -528,10 +528,17 @@ socket.on('team:bid_free', ({ value }, cb) => {
 
 
     team.credits -= p;
-    const player = room.viewPlayers[room.currentIndex];
-    last.playerName = player?.name || '(??)';
-    last.role = player?.role || '';
-    team.acquisitions.push({ player: last.playerName, role: last.role, price: p, at: Date.now() });
+    const playerName = last.playerName && String(last.playerName).trim() ? last.playerName : '(??)';
+    const role = last.role || '';
+    const playerTeam = last.playerTeam || '';
+    const playerFm = last.playerFm ?? null;
+
+    last.playerName = playerName;
+    last.role = role;
+    last.playerTeam = playerTeam;
+    last.playerFm = playerFm;
+
+    team.acquisitions.push({ player: playerName, role, price: p, at: Date.now() });
 
     removeCurrentFromMaster(room);
 
@@ -672,7 +679,7 @@ socket.on('host:undoPurchase', ({ historyId }, cb) => {
   }
 
   // 3) rimetti il giocatore nel master
-  addBackToMaster(room, { name: h.playerName, role: h.role });
+  addBackToMaster(room, { name: h.playerName, role: h.role, team: h.playerTeam, fm: h.playerFm });
 
   // 4) rimuovi la voce di storico
   room.history.splice(idx, 1);

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -93,11 +93,31 @@ export function rebuildView(room, startLetter /* opzionale: 'A'..'Z' */){
 
 
 export function removeCurrentFromMaster(room){
-  const cp = room.viewPlayers[room.currentIndex];
-  if (!cp) return;
-  const idx = room.players.findIndex(p => p.name === cp.name && p.role === cp.role);
-  if (idx >= 0) room.players.splice(idx, 1);
-  rebuildView(room);
+  const last = room.history[room.history.length - 1];
+  if (!last) return;
+
+  const targetName = last.playerName || '';
+  const targetRole = last.role || '';
+  if (!targetName || !targetRole) return;
+
+  const idx = room.players.findIndex(p => {
+    if (!p) return false;
+    if (p.name !== targetName || p.role !== targetRole) return false;
+
+    if (last.playerTeam && (p.team || '') !== last.playerTeam) return false;
+
+    if (last.playerFm != null && last.playerFm !== '') {
+      if (p.fm != null && p.fm !== '') return String(p.fm) === String(last.playerFm);
+      return true;
+    }
+
+    return true;
+  });
+
+  if (idx >= 0) {
+    room.players.splice(idx, 1);
+    rebuildView(room);
+  }
 }
 
 export function addBackToMaster(room, player){
@@ -172,7 +192,9 @@ export function mkHistoryPending(room){
     teamName: team.name,
     price: room.topBid || 0,
     playerName: cur?.name || '',           // subito nome/ruolo correnti
-    role: cur?.role || ''
+    role: cur?.role || '',
+    playerTeam: cur?.team || '',
+    playerFm: cur?.fm ?? null
   };
 
   room.history.push(entry);


### PR DESCRIPTION
## Summary
- persist the team and fantamedia snapshot for each pending history entry
- consume the stored history snapshot during auto-assignment instead of relying on the filtered view
- delete players from the master list using the saved history metadata to avoid removing the wrong entry
- restore undo to reinsert team and fantamedia metadata when adding a player back to the master list
- update the host toggle handler so the PIN prompt is only marked as asked after a successful login and is reset after errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad10e7610832a911f772c155dd269