### PR TITLE
Prevent filter changes during live auction

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -220,7 +220,23 @@ function applyState(s){
   $('btnHostToggle').title = hostLockedByOther ? 'Banditore già assegnato' : '';
 
   const duringAuction = ['RUNNING','ARMED','COUNTDOWN'].includes(s.phase);
-$('btnRollToggle').disabled = !youAreHost || duringAuction;
+  $('btnRollToggle').disabled = !youAreHost || duringAuction;
+
+  const filtersLockedMsg = 'Puoi cambiare filtri solo quando l’asta è ferma o dopo l’assegnazione.';
+  const searchInput = $('searchPlayer');
+  if (searchInput) {
+    searchInput.disabled = duringAuction;
+    searchInput.title = duringAuction ? filtersLockedMsg : '';
+  }
+  document.querySelectorAll('.rolebar .role').forEach((btn) => {
+    btn.disabled = duringAuction;
+    btn.title = duringAuction ? filtersLockedMsg : '';
+  });
+  const btnRandom = $('btnRandom');
+  if (btnRandom) {
+    btnRandom.disabled = duringAuction;
+    btnRandom.title = duringAuction ? filtersLockedMsg : '';
+  }
 
     // Slot
     drawSlotWindow(s.currentPlayer, s.prevPlayer, s.nextPlayer);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -360,8 +360,14 @@ socket.on('host:toggle', ({ pin } = {}, cb) => {
   }
 });
 
+const FILTER_LOCKED_PHASES = ['RUNNING','ARMED','COUNTDOWN'];
+const FILTER_LOCKED_ERROR = 'Puoi cambiare filtri solo quando l’asta è ferma o dopo l’assegnazione.';
+
 socket.on('host:setFilterName', ({ q }, cb) => {
   if (room.hostOwner !== socket.id) return cb && cb({ error: 'Non sei il banditore' });
+  if (FILTER_LOCKED_PHASES.includes(room.phase)) {
+    return cb && cb({ error: FILTER_LOCKED_ERROR });
+  }
   room.filterName = String(q || '');
   rebuildView(room);
   saveRoomSnapshot(serialize(room));
@@ -374,6 +380,9 @@ socket.on('host:setFilterName', ({ q }, cb) => {
   /* FILTRO RUOLO E RANDOM */
   socket.on('host:setRoleFilter', ({ role }, cb) => {
     if (room.hostOwner !== socket.id) return cb && cb({ error: 'Non sei il banditore' });
+    if (FILTER_LOCKED_PHASES.includes(room.phase)) {
+      return cb && cb({ error: FILTER_LOCKED_ERROR });
+    }
     const allowed = ['ALL','P','D','C','A'];
     const r = (role || 'ALL').toUpperCase();
     if (!allowed.includes(r)) return cb && cb({ error: 'Ruolo non valido' });
@@ -387,6 +396,9 @@ socket.on('host:setFilterName', ({ q }, cb) => {
 
   socket.on('host:randomStart', (_, cb) => {
     if (room.hostOwner !== socket.id) return cb && cb({ error: 'Non sei il banditore' });
+    if (FILTER_LOCKED_PHASES.includes(room.phase)) {
+      return cb && cb({ error: FILTER_LOCKED_ERROR });
+    }
     const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
     const pick = letters[Math.floor(Math.random() * letters.length)];
     const { usedStart } = rebuildView(room, pick);


### PR DESCRIPTION
## Summary
- block host filter updates while the auction is running, armed, or counting down so the view cannot jump mid-bid
- disable the host role filters, random start, and search input during live bidding and surface a helpful tooltip
- return a clearer error message telling the host filters can change only when the auction is stopped or after assignment

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbd22c0cc0832ab427ba26a9841e84