### PR TITLE
Fix addBackToMaster to preserve metadata during undo

### DIFF
--- a/server/src/state.js
+++ b/server/src/state.js
@@ -121,9 +121,44 @@ export function removeCurrentFromMaster(room){
 }
 
 export function addBackToMaster(room, player){
-  // evita doppioni
-  const exists = room.players.some(p => p.name === player.name && p.role === player.role);
-  if (!exists) room.players.push({ name: player.name, role: player.role, team: player.team || '', fm: player.fm });
+  if (!player || !player.name || !player.role) {
+    rebuildView(room);
+    return;
+  }
+
+  const normTeam = typeof player.team === 'string' ? player.team.trim() : player.team;
+  const hasTeam = normTeam !== undefined && normTeam !== null && String(normTeam).trim() !== '';
+  const teamValue = hasTeam ? String(normTeam).trim() : '';
+
+  const hasFm = player.fm !== undefined && player.fm !== null && String(player.fm).trim() !== '';
+  const fmValue = hasFm ? String(player.fm).trim() : null;
+
+  const exists = room.players.some(p => {
+    if (!p) return false;
+    if ((p.name || '') !== player.name || (p.role || '') !== player.role) return false;
+
+    if (hasTeam) {
+      const pt = p.team !== undefined && p.team !== null ? String(p.team).trim() : '';
+      if (pt !== teamValue) return false;
+    }
+
+    if (hasFm) {
+      const pfm = p.fm !== undefined && p.fm !== null ? String(p.fm).trim() : null;
+      if (pfm !== fmValue) return false;
+    }
+
+    return true;
+  });
+
+  if (!exists) {
+    const toAdd = {
+      name: player.name,
+      role: player.role,
+      team: hasTeam ? teamValue : String(player?.team ?? '').trim(),
+      fm: hasFm ? player.fm : (player?.fm ?? null)
+    };
+    room.players.push(toAdd);
+  }
   rebuildView(room);
 }
 


### PR DESCRIPTION
## Summary
- extend `addBackToMaster` to compare players using team and FM metadata when available
- ensure reinsertion retains provided team/FM values while still supporting entries without metadata

## Testing
- node - <<'NODE'
import { makeRoom, rebuildView, removeCurrentFromMaster, addBackToMaster, snapshot } from './server/src/state.js';

const roomId = 'test-room-2';
const room = makeRoom(roomId);
room.players = [
  { name: 'Mario Rossi', role: 'D', team: 'TeamA', fm: 10 },
  { name: 'Mario Rossi', role: 'D', team: 'TeamB', fm: 12 },
];
rebuildView(room);
console.log('initial view', room.viewPlayers);
room.currentIndex = 0;
room.history.push({ playerName: 'Mario Rossi', role: 'D', playerTeam: 'TeamA', playerFm: 10 });
removeCurrentFromMaster(room);
console.log('after remove view', room.viewPlayers);

addBackToMaster(room, { name: 'Mario Rossi', role: 'D', team: 'TeamA', fm: 10 });
console.log('after add view', room.viewPlayers);

const snap = snapshot(room);
console.log('snapshot view for new clients', snap.currentPlayer, snap.nextPlayer, snap.prevPlayer);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cbd7f14248832a8edef5ef5c36eaae