### PR TITLE
Ensure host recovery tracks client identifiers

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -468,6 +468,16 @@ io.on('connection', socket => {
   const auth = socket.handshake?.auth || {};
   const claimedClientId = typeof auth.clientId === 'string' && auth.clientId ? auth.clientId : null;
   const claimedHostToken = typeof auth.hostToken === 'string' && auth.hostToken ? auth.hostToken : null;
+  socket.data = socket.data || {};
+  socket.data.clientId = claimedClientId || socket.data.clientId || null;
+
+  if (!socket.data.clientId) {
+    const generatedId = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : crypto.randomBytes(16).toString('hex');
+    socket.data.clientId = generatedId;
+    socket.emit('session:clientId', { clientId: generatedId });
+  }
   const liveSockets = io.of('/').sockets;
   if (room.hostOwner && !liveSockets.has(room.hostOwner)) {
     room.hostOwner = null;
@@ -476,15 +486,15 @@ io.on('connection', socket => {
   let hostRecovered = false;
   const canRecoverHost = !room.hostOwner
     && room.hostOwnerClientId
-    && claimedClientId
-    && room.hostOwnerClientId === claimedClientId
+    && socket.data.clientId
+    && room.hostOwnerClientId === socket.data.clientId
     && room.hostToken
     && claimedHostToken
     && claimedHostToken === room.hostToken;
 
   if (canRecoverHost) {
     room.hostOwner = socket.id;
-    room.hostOwnerClientId = claimedClientId;
+    room.hostOwnerClientId = socket.data.clientId || null;
     hostRecovered = true;
   }
 
@@ -558,7 +568,7 @@ socket.on('host:toggle', ({ pin } = {}, cb) => {
   if (!room.hostOwner) {
     if (HOST_PIN && pin !== HOST_PIN) return cb && cb({ error: 'PIN mancante o errato' });
     room.hostOwner = socket.id;
-    room.hostOwnerClientId = socket.data?.clientId || null;
+    room.hostOwnerClientId = socket.data.clientId || null;
     if (room.phase === 'LOBBY') room.phase = 'ROLLING';
     const token = issueHostToken(room);
     saveRoomSnapshot(serialize(room));
@@ -645,9 +655,7 @@ socket.on('host:reclaim', ({ token }, cb)=>{
     return cb && cb({ error: 'Token host non valido' });
   }
   room.hostOwner = socket.id;
-  if (socket.data?.clientId) {
-    room.hostOwnerClientId = socket.data.clientId;
-  }
+  room.hostOwnerClientId = socket.data.clientId || null;
   saveRoomSnapshot(serialize(room));
   cb && cb({ ok:true });
   broadcast(room);


### PR DESCRIPTION
## Summary
- persist the connecting clientId on the socket and generate one for legacy clients
- tighten host recovery to require matching clientId and populate host ownership metadata consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da527a069c832a8d2059d0c4936296