### PR TITLE
Fix unbalanced braces in client countdown script

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -140,6 +140,8 @@ function updateCountdownUI(phase, countdownSec) {
   el.textContent = display;
   el.classList.remove(...countdownClasses);
   if (state) el.classList.add(state);
+}
+
 function renderEmptyState(listEl, message) {
   if (!listEl) return;
   const li = document.createElement('li');
@@ -849,7 +851,6 @@ $('btnHostViewControls')?.addEventListener('click', ()=>{
     syncSearchVisibility(window.__last_state);
   }
 });
-}
 
 
 


### PR DESCRIPTION
## Summary
- close the updateCountdownUI helper after applying countdown styles
- remove the stray closing brace left at the end of the host view switch handlers

## Testing
- node --check client/public/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dbcdfc39f8832aa597b1c284a01358