### PR TITLE
Fix host token helper placement

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -9,6 +9,28 @@ function bootstrapStoredHostToken() {
   if (token) setStoredHostToken(token);
 }
 
+function setStoredHostToken(token) {
+  storedHostToken = token || null;
+  try {
+    if (storedHostToken) {
+      localStorage.setItem('hostToken', storedHostToken);
+    } else {
+      localStorage.removeItem('hostToken');
+    }
+  } catch (_) {}
+  socket.auth = socket.auth || {};
+  if (storedHostToken) {
+    socket.auth.hostToken = storedHostToken;
+  } else if (socket?.auth && 'hostToken' in socket.auth) {
+    delete socket.auth.hostToken;
+  }
+}
+
+function getHostToken() {
+  if (socket?.auth?.hostToken) return socket.auth.hostToken;
+  return storedHostToken;
+}
+
 function ensureClientId() {
   let id = null;
   try {
@@ -149,28 +171,6 @@ function renderEmptyState(listEl, message) {
   li.classList.add('empty-state');
   li.textContent = message;
   listEl.appendChild(li);
-}
-
-function setStoredHostToken(token) {
-  storedHostToken = token || null;
-  try {
-    if (storedHostToken) {
-      localStorage.setItem('hostToken', storedHostToken);
-    } else {
-      localStorage.removeItem('hostToken');
-    }
-  } catch (_) {}
-  socket.auth = socket.auth || {};
-  if (storedHostToken) {
-    socket.auth.hostToken = storedHostToken;
-  } else if (socket?.auth && 'hostToken' in socket.auth) {
-    delete socket.auth.hostToken;
-  }
-}
-
-function getHostToken() {
-  if (socket?.auth?.hostToken) return socket.auth.hostToken;
-  return storedHostToken;
 }
 
 /* ===== RENDER LATO PARTECIPANTI ===== */


### PR DESCRIPTION
## Summary
- move the host token storage helpers next to the initialization block before their first usage
- keep `getHostToken` as a function declaration immediately following `setStoredHostToken` to benefit from hoisting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbd3d9e574832a9f08c781c335babc