### PR TITLE
Update cache busting for client assets

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -181,6 +181,6 @@
   <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
   <!-- SheetJS per lettura XLSX lato client -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
-  <script src="/app.js?v=1"></script>
+  <script src="/app.js?v=2"></script>
 </body>
 </html>

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -42,7 +42,15 @@ app.use(express.json({ limit: '5mb' }));
 
 const STATIC_DIR = path.resolve(__dirname, '../../client/public');
 app.use('/', express.static(STATIC_DIR, {
-  setHeaders(res, filePath){ if (filePath.endsWith('index.html')) res.setHeader('Cache-Control', 'no-store'); }
+  setHeaders(res, filePath) {
+    if (filePath.endsWith('index.html')) {
+      res.setHeader('Cache-Control', 'no-store');
+      return;
+    }
+    if (/\.(?:js|css)$/.test(filePath)) {
+      res.setHeader('Cache-Control', 'no-store');
+    }
+  }
 }));
 
 const ROOM_ID = 'DEFAULT';


### PR DESCRIPTION
## Summary
- bump the app.js cache-busting query string so clients fetch the latest bundle
- configure express static middleware to disable caching for served HTML, JS, and CSS assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe17b05f4832a98b2905a667e12f3