### PR TITLE
Fix navbar visibility flicker during roll refresh

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -874,6 +874,7 @@ $('btnHostViewControls')?.addEventListener('click', ()=>{
   let isHidden = false;
   let ticking = false;
   let debounceTimer = null;
+  let recheckTimer = null;
   const HIDE_THRESHOLD = 30; // Nascondi quando più vicino di 30px
   const SHOW_THRESHOLD = 150; // Mostra quando più lontano di 150px
 
@@ -934,9 +935,19 @@ $('btnHostViewControls')?.addEventListener('click', ()=>{
 
   // Re-check quando cambia lo stato (es. diventi banditore)
   window.addEventListener('navbar:recheck', () => {
-    isHidden = false;
-    navbar.classList.remove('hidden');
-    setTimeout(updateNavbar, 100);
+    // Non forzare la visibilità: durante i piccoli assestamenti di layout (es. rullo)
+    // la distanza reale potrebbe non essere cambiata abbastanza da richiedere il
+    // toggle. Limitandoci a programmare un nuovo calcolo evitiamo che la navbar
+    // venga mostrata per poi essere subito nascosta, eliminando il lampeggio.
+    clearTimeout(debounceTimer);
+    if (recheckTimer) {
+      clearTimeout(recheckTimer);
+    }
+    recheckTimer = setTimeout(() => {
+      ticking = false;
+      requestTick();
+      recheckTimer = null;
+    }, 100);
   });
 
   // Check iniziale


### PR DESCRIPTION
## Summary
- keep the navbar hidden during recheck events and schedule a recalculation instead of forcing visibility
- debounce repeated navbar rechecks to avoid repeated recalculations and flicker when the roll updates the layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd2c22bfd8832a95fab2f48a415a1d