### PR TITLE
Add canonical sold event and host manual assignment tools

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -44,26 +44,42 @@
      <aside class="col col-left">
   <!-- CONTROLLI (solo per host, nella vista "Controlli") -->
   <div class="card" id="ctrlCard">
-    <div class="row space-between">
-      <h2 class="text-center">Controllo</h2>
-      <div class="chip" id="hostStatus">Partecipante</div>
+    <header class="host-card-header">
+      <h2>Controllo banditore</h2>
+      <div class="chip host-status hidden" id="hostStatus">Banditore attivo</div>
+    </header>
+
+    <div class="host-actions-grid" role="group" aria-label="Azioni banditore">
+      <button id="btnHostToggle" class="btn btn-outline host-action" title="Prendi o lascia il ruolo di banditore">Banditore</button>
+      <button id="btnHostSkip" class="btn btn-outline host-action" title="Salta al prossimo giocatore">Salta giocatore</button>
+      <button id="btnHostBackN" class="btn btn-outline host-action" title="Torna indietro di N posizioni">Indietro di N</button>
+      <button id="btnRandom" class="btn btn-outline host-action" title="Scegli una lettera casuale come partenza">Lettera casuale</button>
     </div>
 
-    <div class="row gap">
-      <button id="btnHostToggle" class="btn btn-outline">Banditore</button>
-      <div class="row gap">
-        <button id="btnHostSkip" class="btn btn-outline">Salta</button>
-        <button id="btnHostBackN" class="btn btn-outline">Indietro di N</button>
+    <div class="rolebar" id="rolebar" role="group" aria-label="Filtra per ruolo">
+      <button class="role btn" data-role="P" title="Mostra solo i portieri">P</button>
+      <button class="role btn" data-role="D" title="Mostra solo i difensori">D</button>
+      <button class="role btn" data-role="C" title="Mostra solo i centrocampisti">C</button>
+      <button class="role btn" data-role="A" title="Mostra solo gli attaccanti">A</button>
+    </div>
+
+    <div class="host-search-row">
+      <input id="searchPlayer" class="input" placeholder="Cerca giocatore..." aria-label="Cerca giocatore" />
+    </div>
+
+    <div class="manual-assign" id="manualAssignSection" style="display:none">
+      <div class="manual-assign-head">
+        <h3>Assegna manualmente</h3>
+        <p class="manual-assign-note">Seleziona squadra e crediti. Il sistema richiede doppia conferma prima di completare.</p>
       </div>
-    </div>
-
-    <div class="rolebar" id="rolebar">
-      <button class="role btn" data-role="P">P</button>
-      <button class="role btn" data-role="D">D</button>
-      <button class="role btn" data-role="C">C</button>
-      <button class="role btn" data-role="A">A</button>
-      <button id="btnRandom" class="btn btn-outline w-100">Random</button>
-      <input id="searchPlayer" class="input" placeholder="Cerca giocatore..." style="margin-left:.5rem; width: 14rem;" />
+      <div class="manual-assign-summary" id="assignPlayerSummary">Nessun giocatore in evidenza</div>
+      <div class="manual-assign-grid">
+        <select id="assignTeamSelect" class="input" aria-label="Seleziona squadra destinataria">
+          <option value="">Seleziona squadra…</option>
+        </select>
+        <input id="assignPrice" class="input" type="number" min="0" step="1" placeholder="Prezzo" aria-label="Prezzo di assegnazione" />
+        <button id="btnAssignManual" type="button" class="btn btn-primary" title="Assegna il giocatore corrente">Assegna</button>
+      </div>
     </div>
   </div>
 

--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -20,6 +20,7 @@
   --toast-success: linear-gradient(135deg, #16a34a, #15803d);
   --toast-error: linear-gradient(135deg, #ef4444, #b91c1c);
   --toast-info: linear-gradient(135deg, #2563eb, #1d4ed8);
+  --toast-warn: linear-gradient(135deg, #f59e0b, #d97706);
   --radius: 18px;
 }
 
@@ -447,7 +448,6 @@ body {
   color: #f8fafc;
   font-weight: 700;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, .25), 0 12px 24px rgba(37, 99, 235, .2);
-  margin-top: 20px;
 }
 
 #btnHostToggle:disabled {
@@ -463,6 +463,32 @@ body {
   color: #507089;
   font-size: 12px;
   font-weight: 600;
+}
+
+/* Toast con contatore duplicati */
+.toast-with-counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.toast-with-counter .toast-message {
+  flex: 1 1 auto;
+}
+
+.toast-with-counter .toast-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, .22);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: .05em;
+  font-size: .85em;
 }
 
 .badge {
@@ -924,6 +950,97 @@ summary:focus-visible {
   border-color: #38bdf8;
   font-weight: 800;
   box-shadow: 0 0 0 2px rgba(56, 189, 248, .25);
+}
+
+/* Layout pannello banditore */
+.host-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.host-card-header h2 {
+  margin: 0;
+}
+
+.host-actions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.host-actions-grid .btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.host-search-row {
+  margin-top: 12px;
+}
+
+.host-search-row .input {
+  width: 100%;
+}
+
+.manual-assign {
+  margin-top: 18px;
+  padding: 16px;
+  border: 1px solid var(--outline);
+  border-radius: 14px;
+  background: var(--surface-2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.manual-assign-head h3 {
+  margin: 0;
+}
+
+.manual-assign-note {
+  margin: 4px 0 0;
+  font-size: .85em;
+  color: var(--muted);
+}
+
+.manual-assign-summary {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.manual-assign-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: center;
+}
+
+.manual-assign-grid select,
+.manual-assign-grid input {
+  width: 100%;
+}
+
+.manual-assign-grid button {
+  grid-column: span 2;
+}
+
+@media (min-width: 640px) {
+  .host-actions-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .manual-assign-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .manual-assign-grid button {
+    grid-column: span 1;
+  }
 }
 
 /* ===== Bids ===== */


### PR DESCRIPTION
## Summary
- emit a single `auction:sold` event from the server and listen to it on the client instead of inferring sales
- introduce manual player assignment for the host with validation and a refreshed host control panel layout
- centralize toast notifications with coalescing/severity support and update styling for the new UI controls

## Testing
- not run (tests not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4a7f33d8832abe168cea5350f805