### PR TITLE
Limit host back steps

### DIFF
--- a/client/public/app.js
+++ b/client/public/app.js
@@ -895,8 +895,32 @@ $('btnHostSkip').onclick = () =>
   socket.emit('host:skip', {}, (res)=> res?.error ? notify(res.error,'error') : notify('Avanti di uno','info'));
 
 $('btnHostBackN').onclick = () => {
-  const n = Number(prompt('Quanti indietro?', '1') || '1');
-  socket.emit('host:backN', { n }, (res)=> res?.error ? notify(res.error,'error') : notify(`Indietro di ${n}`,'info'));
+  const input = prompt('Quanti indietro?', '1');
+  if (input === null) return;
+
+  const parsed = Math.floor(Number(input));
+  if (!Number.isFinite(parsed)) {
+    notify('Inserisci un numero valido', 'warn');
+    return;
+  }
+
+  let effective = parsed;
+  if (effective < 1) {
+    effective = 1;
+    notify('Valore troppo basso, imposto a 1', 'warn');
+  } else if (effective > 10) {
+    effective = 10;
+    notify('Valore troppo alto, imposto a 10', 'warn');
+  }
+
+  socket.emit('host:backN', { n: effective }, (res = {}) => {
+    if (res.error) {
+      notify(res.error, 'error');
+      return;
+    }
+    const applied = Number.isFinite(res.applied) ? res.applied : effective;
+    notify(`Indietro di ${applied}`, 'info');
+  });
 };
 
 manualAssignButton?.addEventListener('click', () => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1181,12 +1181,15 @@ io.on('connection', (socket) => {
     if (room.hostOwner !== socket.id) return cb && cb({ error: 'Non sei il banditore' });
     if (!room.viewPlayers.length) return cb && cb({ error: 'Lista vuota' });
     if (['RUNNING', 'ARMED', 'COUNTDOWN'].includes(room.phase)) return cb && cb({ error: 'Ferma l’asta prima' });
-    const k = Math.max(1, Math.floor(Number(n || 1)));
+    const parsed = Math.floor(Number(n));
+    if (!Number.isFinite(parsed)) return cb && cb({ error: 'Valore non valido' });
+    const k = Math.max(1, Math.min(10, parsed));
+    if (parsed !== k) return cb && cb({ error: 'Puoi tornare indietro da 1 a 10 giocatori' });
     const len = room.viewPlayers.length;
     room.currentIndex = ((room.currentIndex - (k % len)) + len) % len;
     persistRoom(room);
     broadcast(room);
-    cb && cb({ ok: true, index: room.currentIndex });
+    cb && cb({ ok: true, index: room.currentIndex, applied: k });
   });
 
   socket.on('host:pinPlayer', ({ index }, cb) => {


### PR DESCRIPTION
## Summary
- enforce the `host:backN` handler to only accept numeric values between 1 and 10 and report the applied offset
- normalise the host back control input on the client, warn when corrected, and display the effective step count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4c50c390832aa1f8ca04c309c91e