### PR TITLE
Refine commented JWT auth guidance

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -32,6 +32,40 @@
         <span class="knob"></span><span class="label">Dirigi l’asta</span>
       </label>
       <button id="btnEnter" class="btn btn-outline">Entra</button>
+      <!--
+        =============================================================
+        AUTENTICAZIONE UTENTI (COMMENTATA)
+        -------------------------------------------------------------
+        Per introdurre il login registrati, scommentare il markup qui
+        sotto e collegarlo alle funzioni presenti in app.js.
+        Istruzioni operative:
+        1. Aggiungere i campi email/password/displayName.
+        2. Mostrare/nascondere il form in base allo stato auth.
+        3. Inviare i dati con `signupUser`/`loginUser`.
+        4. Visualizzare lo stato corrente nell'`#authStatusBox` quando
+           l'utente è loggato.
+        Nota layout: idealmente questo blocco dovrebbe vivere in una card
+        separata (o tab dedicato) rispetto ai campi squadra, così le due
+        esperienze restano distinte.
+      =============================================================
+      <div class="auth-card mt-lg" id="authBox">
+        <h2 class="h5">Accedi con il tuo account</h2>
+        <div class="auth-stack gap-sm">
+          <label class="visually-hidden" for="authEmail">Email</label>
+          <input id="authEmail" type="email" class="input" placeholder="Email" autocomplete="email" />
+          <label class="visually-hidden" for="authPassword">Password</label>
+          <input id="authPassword" type="password" class="input" placeholder="Password" autocomplete="current-password" />
+        </div>
+        <div class="auth-row gap mt-sm">
+          <button id="btnLogin" class="btn btn-primary" type="button">Login</button>
+          <button id="btnSignup" class="btn btn-outline" type="button">Registrati</button>
+        </div>
+        <p class="muted mt-sm" id="authHint">L’account controlla solo il tuo profilo: la gestione squadre resta invariata.</p>
+      </div>
+      <div id="authStatusBox" class="auth-card mt-sm" hidden>
+        <!-- Quando attivo, mostrare qualcosa come: "Bentornato X" e bottone Logout -->
+      </div>
+      -->
     </div>
   </section>
 

--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -650,6 +650,40 @@ body {
   color: var(--muted);
 }
 
+/*
+==================================================================
+ FUTURE AUTH STYLES (COMMENTATE)
+ -----------------------------------------------------------------
+ Scommentare questo blocco quando si attiverà il form di login
+ utenti presente in index.html. Le classi sono pensate per
+ integrarsi con lo stile attuale senza rompere il layout.
+==================================================================
+ .auth-card {
+   border-top: 1px solid rgba(15, 23, 42, 0.12);
+   padding-top: 1.5rem;
+   /* Opzionale: usare `background: var(--bg-muted);` per evidenziare la separazione dal form squadra. */
+ }
+
+ .auth-card .auth-stack {
+   display: flex;
+   flex-direction: column;
+   gap: 0.75rem;
+ }
+
+ .auth-card .auth-row {
+   display: flex;
+   gap: 0.75rem;
+   flex-wrap: wrap;
+ }
+
+ .auth-card .auth-row .btn {
+   flex: 1 1 140px;
+ }
+
+ /* Nota: valutare una media query (es. max-width: 400px) per portare i bottoni al 100% in mobile. */
+==================================================================
+*/
+
 .card-note {
   font-size: .9rem;
   line-height: 1.5;

--- a/server/src/storage.js
+++ b/server/src/storage.js
@@ -78,3 +78,116 @@ export function writeBackupFile(snap) {
   }
 }
 
+/*
+////////////////////////////////////////////////////////////////
+// PERSISTENZA UTENTI REGISTRATI (COMMENTATA)
+// --------------------------------------------------------------
+// Il blocco sottostante implementa una semplice persistenza su
+// file JSON per utenti e sessioni JWT. Scommentarlo solo dopo
+// aver aggiunto le dipendenze e le route che ne fanno uso.
+//
+// NOTE OPERATIVE:
+// - Il file `users.json` viene creato automaticamente nella
+//   cartella `data` già usata per gli snapshot.
+// - Attenzione: le sessioni sono tenute solo in memoria (Map);
+//   ogni riavvio dell'app azzera tutte le sessioni attive.
+////////////////////////////////////////////////////////////////
+// const USERS_FILE = path.join(DATA_DIR, 'users.json');
+// const userSessionRegistry = new Map();
+//
+// async function ensureUsersFile() {
+//   if (fs.existsSync(USERS_FILE)) return;
+//   await fs.promises.writeFile(USERS_FILE, '[]', 'utf8');
+// }
+//
+// export async function readUsers() {
+//   try {
+//     await ensureUsersFile();
+//     const raw = await fs.promises.readFile(USERS_FILE, 'utf8');
+//     const parsed = JSON.parse(raw);
+//     if (!Array.isArray(parsed)) {
+//       console.warn('[readUsers] formato inatteso, resetto a []');
+//       await fs.promises.writeFile(USERS_FILE, '[]', 'utf8');
+//       return [];
+//     }
+//     return parsed;
+//   } catch (err) {
+//     console.error('[readUsers] errore lettura utenti:', err);
+//     return [];
+//   }
+// }
+//
+// export async function writeUsers(users) {
+//   try {
+//     const json = JSON.stringify(users, null, 2);
+//     // Nota: scrittura concorrente non protetta; meglio prevedere lock o DB.
+//     await fs.promises.writeFile(USERS_FILE, json, 'utf8');
+//     return true;
+//   } catch (err) {
+//     console.error('[writeUsers] errore salvataggio utenti:', err);
+//     return false;
+//   }
+// }
+//
+// export function touchUserSession(userId, token, ttl) {
+//   if (!userId || !token) return false;
+//   const now = Date.now();
+//   const ms = parseJwtExpiry(ttl);
+//   const expiresAt = ms > 0 ? now + ms : now + 12 * 60 * 60 * 1000;
+//   userSessionRegistry.set(token, { userId, expiresAt });
+//   pruneSessions(now);
+//   return true;
+// }
+//
+// export function revokeUserSession(token) {
+//   if (!token) return;
+//   // Revoca solo la singola sessione associata a questo token. Per invalidare
+//   // tutte le sessioni di un utente servirà mantenere un indice per userId.
+//   userSessionRegistry.delete(token);
+// }
+//
+// export function isSessionValid(token) {
+//   if (!token) return false;
+//   const data = userSessionRegistry.get(token);
+//   if (!data) return false;
+//   if (Date.now() > data.expiresAt) {
+//     userSessionRegistry.delete(token);
+//     return false;
+//   }
+//   return true;
+// }
+//
+// function pruneSessions(now = Date.now()) {
+//   for (const [token, data] of userSessionRegistry.entries()) {
+//     if (!data || now > data.expiresAt) userSessionRegistry.delete(token);
+//   }
+// }
+//
+// function parseJwtExpiry(value) {
+//   if (value == null) return 0;
+//   if (typeof value === 'number' && Number.isFinite(value)) {
+//     return value > 0 ? value * 1000 : 0;
+//   }
+//   const str = String(value).trim();
+//   if (!str) return 0;
+//   if (/^\d+$/.test(str)) return Number(str) * 1000;
+//   const match = str.match(/^(\d+)([smhd])$/i);
+//   if (!match) {
+//     console.warn('[parseJwtExpiry] formato TTL non riconosciuto:', value);
+//     return 0;
+//   }
+//   const qty = Number(match[1]);
+//   const unit = match[2].toLowerCase();
+//   switch (unit) {
+//     case 's': return qty * 1000;
+//     case 'm': return qty * 60 * 1000;
+//     case 'h': return qty * 60 * 60 * 1000;
+//     case 'd': return qty * 24 * 60 * 60 * 1000;
+//     default:
+//       console.warn('[parseJwtExpiry] unità TTL non supportata:', unit);
+//       return 0;
+//   }
+// }
+////////////////////////////////////////////////////////////////
+*/
+


### PR DESCRIPTION
## Summary
- update the commented client auth helpers to centralise session restore, log JSON parse issues, toggle button disabled state, and persist sessions under authUserSession
- adjust the commented login markup and styles for clearer separation, accessibility labels, and a future auth status box
- clarify the commented server and storage scaffolding with header-over-cookie precedence, signup email validation, socket role notes, stricter token handling, and session TTL parsing guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de59583150832ab992a04adce5a9d8